### PR TITLE
chore: upgrade to Vue 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "firebase-admin": "^13.4.0",
         "register-service-worker": "^1.7.2",
         "v-offline": "^1.3.0",
-        "vue": "^2.6.14",
-        "vue-router": "^3.5.1",
-        "vuetify": "^2.6.0",
-        "vuex": "^3.6.2"
+        "vue": "^3.5.18",
+        "vue-router": "^4.5.1",
+        "vuetify": "^3.9.4",
+        "vuex": "^4.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.16",
@@ -28,11 +28,10 @@
         "@vue/cli-plugin-router": "~5.0.0",
         "@vue/cli-plugin-vuex": "~5.0.0",
         "@vue/cli-service": "~5.0.0",
+        "@vue/compiler-sfc": "^3.5.18",
         "eslint": "^7.32.0",
         "eslint-plugin-vue": "^8.0.3",
-        "material-design-icons-iconfont": "^6.7.0",
-        "vue-cli-plugin-vuetify": "~2.5.8",
-        "vue-template-compiler": "^2.6.14"
+        "material-design-icons-iconfont": "^6.7.0"
       }
     },
     "node_modules/@achrinza/node-ipc": {
@@ -2452,8 +2451,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
-      "dev": true
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
@@ -3536,39 +3534,39 @@
       "dev": true
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
-      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
-      "dev": true,
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
+      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.5.17",
+        "@babel/parser": "^7.28.0",
+        "@vue/shared": "3.5.18",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
-      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
-      "dev": true,
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
+      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.17",
-        "@vue/shared": "3.5.17"
+        "@vue/compiler-core": "3.5.18",
+        "@vue/shared": "3.5.18"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
-      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
-      "dev": true,
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.18.tgz",
+      "integrity": "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.5.17",
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/compiler-ssr": "3.5.17",
-        "@vue/shared": "3.5.17",
+        "@babel/parser": "^7.28.0",
+        "@vue/compiler-core": "3.5.18",
+        "@vue/compiler-dom": "3.5.18",
+        "@vue/compiler-ssr": "3.5.18",
+        "@vue/shared": "3.5.18",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.17",
         "postcss": "^8.5.6",
@@ -3576,13 +3574,13 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
-      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
-      "dev": true,
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.18.tgz",
+      "integrity": "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/shared": "3.5.17"
+        "@vue/compiler-dom": "3.5.18",
+        "@vue/shared": "3.5.18"
       }
     },
     "node_modules/@vue/component-compiler-utils": {
@@ -3649,11 +3647,61 @@
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.18.tgz",
+      "integrity": "sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.18"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.18.tgz",
+      "integrity": "sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.18",
+        "@vue/shared": "3.5.18"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.18.tgz",
+      "integrity": "sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.18",
+        "@vue/runtime-core": "3.5.18",
+        "@vue/shared": "3.5.18",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.18.tgz",
+      "integrity": "sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.18",
+        "@vue/shared": "3.5.18"
+      },
+      "peerDependencies": {
+        "vue": "3.5.18"
+      }
+    },
     "node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
+      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
+      "license": "MIT"
     },
     "node_modules/@vue/vue-loader-v15": {
       "name": "vue-loader",
@@ -5488,7 +5536,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5545,7 +5594,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -6030,7 +6081,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -6630,7 +6681,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -8297,15 +8348,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -9593,7 +9635,6 @@
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -10089,58 +10130,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/null-loader": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-4.0.1.tgz",
-      "integrity": "sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/null-loader/node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/null-loader/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/object-assign": {
@@ -11204,6 +11193,7 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
       "optional": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -11601,18 +11591,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12334,23 +12312,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -12499,6 +12460,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13641,47 +13603,24 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.18.tgz",
+      "integrity": "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
-        "csstype": "^3.1.0"
-      }
-    },
-    "node_modules/vue-cli-plugin-vuetify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.5.8.tgz",
-      "integrity": "sha512-uqi0/URJETJBbWlQHD1l0pnY7JN8Ytu+AL1fw50HFlGByPa8/xx+mq19GkFXA9FcwFT01IqEc/TkxMPugchomg==",
-      "dev": true,
-      "dependencies": {
-        "null-loader": "^4.0.1",
-        "semver": "^7.1.2",
-        "shelljs": "^0.8.3"
+        "@vue/compiler-dom": "3.5.18",
+        "@vue/compiler-sfc": "3.5.18",
+        "@vue/runtime-dom": "3.5.18",
+        "@vue/server-renderer": "3.5.18",
+        "@vue/shared": "3.5.18"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
+        "typescript": "*"
       },
       "peerDependenciesMeta": {
-        "sass-loader": {
-          "optional": true
-        },
-        "vuetify-loader": {
+        "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vue-cli-plugin-vuetify/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -13819,9 +13758,19 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
-      "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
     },
     "node_modules/vue-style-loader": {
       "version": "4.1.3",
@@ -13844,6 +13793,8 @@
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
       "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "de-indent": "^1.0.2",
         "he": "^1.2.0"
@@ -13855,37 +13806,46 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
-    "node_modules/vue/node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
-      "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
-      }
-    },
     "node_modules/vuetify": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.13.tgz",
-      "integrity": "sha512-HhJi52IzhfrmWFwcYFUiA1GRIzz9smbR06Lj61Ml5HgD5PBcMiDywUnNPVid1VsXO4qWpBU6kO3O89uTxH1yzw==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.9.4.tgz",
+      "integrity": "sha512-OUdXVoThHUydJHyFsUHGxKxZ333hXKquRNn2ycqouO08ehi3005QE9tLPkwcBii4sAYZg7mADMRp7JbcNiNrTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
       },
       "peerDependencies": {
-        "vue": "^2.6.4"
+        "typescript": ">=4.7",
+        "vite-plugin-vuetify": ">=2.1.0",
+        "vue": "^3.5.0",
+        "webpack-plugin-vuetify": ">=3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
+          "optional": true
+        }
       }
     },
     "node_modules/vuex": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
+      "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      },
       "peerDependencies": {
-        "vue": "^2.0.0"
+        "vue": "^3.2.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "firebase-admin": "^13.4.0",
     "register-service-worker": "^1.7.2",
     "v-offline": "^1.3.0",
-    "vue": "^2.6.14",
-    "vue-router": "^3.5.1",
-    "vuetify": "^2.6.0",
-    "vuex": "^3.6.2"
+    "vue": "^3.5.18",
+    "vue-router": "^4.5.1",
+    "vuetify": "^3.9.4",
+    "vuex": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",
@@ -31,7 +31,6 @@
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^8.0.3",
     "material-design-icons-iconfont": "^6.7.0",
-    "vue-cli-plugin-vuetify": "~2.5.8",
-    "vue-template-compiler": "^2.6.14"
+    "@vue/compiler-sfc": "^3.5.18"
   }
 }

--- a/src/components/about/AboutHeader.vue
+++ b/src/components/about/AboutHeader.vue
@@ -1,5 +1,5 @@
 <template>
-    
+  <div></div>
 </template>
 
 <script>

--- a/src/components/blogs/BlogCard.vue
+++ b/src/components/blogs/BlogCard.vue
@@ -4,7 +4,7 @@
       class="mx-auto pa-2"
       max-width="100%"
       flat
-      :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+      :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
     >
       <v-list-item three-line>
         <!-- <v-list-item-avatar tile size="90" style="border-radius: 12px !important;" color="grey">
@@ -27,7 +27,7 @@
               right
               class="mb-0 mt-2 google-font"
               :href="data.data.link"
-              :color="$vuetify.theme.dark ? '#585B5A' : '#DEE4EA'"
+              :color="isDark ? '#585B5A' : '#DEE4EA'"
               >See More
               <v-icon right>mdi-arrow-right-thin</v-icon>
             </v-btn>

--- a/src/components/blogs/BlogsDetails.vue
+++ b/src/components/blogs/BlogsDetails.vue
@@ -71,7 +71,6 @@
 import { mapState } from "vuex";
 import service from "@/services/appservices";
 export default {
-  inject: ["theme"],
   components: {
     BlogCard: () => import("@/components/blogs/BlogCard"),
   },

--- a/src/components/common/SocialInfo.vue
+++ b/src/components/common/SocialInfo.vue
@@ -11,7 +11,7 @@
           :href="data.twitter"
           target="_blank"
         >
-          <v-icon small :color="this.$vuetify.theme.dark == true?'white':'#333'">mdi-twitter</v-icon>
+          <v-icon small :color="isDark ? 'white':'#333'">mdi-twitter</v-icon>
         </v-btn>
 
         <v-btn
@@ -23,7 +23,7 @@
           :href="data.linkedin"
           target="_blank"
         >
-          <v-icon small :color="this.$vuetify.theme.dark == true?'white':'#333'">mdi-linkedin</v-icon>
+          <v-icon small :color="isDark ? 'white':'#333'">mdi-linkedin</v-icon>
         </v-btn>
         <v-btn
           aria-label="social media btn"
@@ -34,18 +34,11 @@
           :href="data.github"
           target="_blank"
         >
-          <v-icon small :color="this.$vuetify.theme.dark == true?'white':'#333'">mdi-github</v-icon>
+          <v-icon small :color="isDark ? 'white':'#333'">mdi-github</v-icon>
         </v-btn>
-        <!-- <v-btn
-          aria-label="social media btn"
-          small
-          class="mt-0 mx-0"
-          icon
-          v-if="checkExistance(data.medium,0)"
-          :href="data.medium"
-          target="_blank"
-        >
-          <v-icon small :color="this.$vuetify.theme.dark == true?'white':'#333'">mdi-medium</v-icon>
+        <!-- <v-btn aria-label="social media btn" small class="mt-0 mx-0" icon
+          v-if="checkExistance(data.medium,0)" :href="data.medium" target="_blank">
+          <v-icon small>mdi-medium</v-icon>
         </v-btn> -->
         <v-btn
           aria-label="social media btn"
@@ -56,7 +49,7 @@
           :href="data.web"
           target="_blank"
         >
-          <v-icon small :color="this.$vuetify.theme.dark == true?'white':'#333'">mdi-link-variant</v-icon>
+          <v-icon small :color="isDark ? 'white':'#333'">mdi-link-variant</v-icon>
         </v-btn>
       </v-col>
     </v-row>

--- a/src/components/events/EventCard.vue
+++ b/src/components/events/EventCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="
-      $vuetify.theme.dark == true
+      isDark
         ? 'aura-darkModeCardFeatureEvent'
         : 'aura-lightModeCardFeatureEvent'
     "
@@ -22,7 +22,7 @@
       right
       class="mb-0 mt-4 google-font"
       @click="goToEvent(data.id)"
-      :color="$vuetify.theme.dark?'#585B5A':'#DEE4EA'"
+      :color="isDark ? '#585B5A':'#DEE4EA'"
       >See More
       <v-icon right>mdi-arrow-right-thin</v-icon>
       </v-btn

--- a/src/components/events/PastEvents.vue
+++ b/src/components/events/PastEvents.vue
@@ -11,7 +11,7 @@
           justify="center"
           align="center"
           class="pa-5"
-          :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+          :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
         >
           <v-col md="6" lg="6" sm="6" cols="12">
             <p class="google-font mb-0" style="font-size: 150%;">
@@ -47,7 +47,7 @@
               sort-by="date"
               sort-desc
               :items-per-page="5"
-              :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+              :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
             >
               <template v-slot:[`item.name`]="{ item }">
                 {{ item.name }}

--- a/src/components/events/UpcomingEventCard.vue
+++ b/src/components/events/UpcomingEventCard.vue
@@ -4,7 +4,7 @@
       <div
         v-on="on"
         style="cursor: pointer;border-left:8px solid #4E5FBB !important"
-        :class="$vuetify.theme.dark == true?'aura-card-dark':'aura-card-light'"
+        :class="isDark ? 'aura-card-dark':'aura-card-light'"
         class="pa-3"
       >
         <!-- <v-chip color="primary" label outlined class="mt-1 mx-0 mb-0" small>{{data.data.status}}</v-chip> -->
@@ -18,7 +18,7 @@
         <p class="mb-0 mt-2 google-font" style="color:#1a73e8">See More</p>
       </div>
     </template>
-    <v-card :class="this.$vuetify.theme.dark == true?'grey darken-3':'white'" v-if="dialog">
+    <v-card :class="isDark ? 'grey darken-3':'white'" v-if="dialog">
       <v-card-title
         class="px-5 py-5 google-font"
         style="background-position:right bottom;"

--- a/src/components/home/Events.vue
+++ b/src/components/home/Events.vue
@@ -29,7 +29,7 @@
         <v-container fluid class="px-2 py-0">
           <v-row v-if="showLoader" class="">
             <v-col v-for="i in 4" :key="i" md="3" lg="3" sm="6" cols="6" class="pa-2">
-              <v-sheet :color="`grey ${theme.isDark ? 'darken-2' : 'lighten-4'}`" class="">
+              <v-sheet :color="`grey ${isDark ? 'darken-2' : 'lighten-4'}`" class="">
                 <v-skeleton-loader class="mx-auto" type="article"></v-skeleton-loader>
               </v-sheet>
             </v-col>
@@ -54,14 +54,20 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import service from "@/services/appservices";
 import eventCard from "@/components/events/UpcomingEventCard";
 import { mapState } from "vuex";
 export default {
   name: "EventsHomePage",
-  inject: ["theme"],
   components: {
     eventCard,
+  },
+  setup() {
+    const theme = useTheme()
+    const isDark = computed(() => theme.global.current.value.dark)
+    return { isDark }
   },
   computed: {
     ...mapState(["config"]),

--- a/src/components/home/FeaturesEvents.vue
+++ b/src/components/home/FeaturesEvents.vue
@@ -13,16 +13,20 @@
         <v-container fluid class="py-0 my-0">
           <v-row class="py-0 my-0" v-if="loading && notFound == false">
             <v-col v-for="i in 4" :key="i" md="3" lg="3" sm="6" cols="6" class="pa-2">
-              <v-sheet :color="`grey ${theme.isDark ? 'darken-2' : 'lighten-4'}`" class>
+              <v-sheet :color="`grey ${isDark ? 'darken-2' : 'lighten-4'}`" class>
                 <v-skeleton-loader class="mx-auto" type="article"></v-skeleton-loader>
               </v-sheet>
             </v-col>
           </v-row>
           <v-row class="py-0 my-0" v-else-if="notFound">
-            <v-col md="3" lg="3" sm="6" cols="12" :class="$vuetify.theme.dark
-                ? 'darkModeCardFeatureEvent'
-                : 'lightModeCardFeatureEvent'
-              " class="pa-4 px-5 mx-3">
+            <v-col
+              md="3"
+              lg="3"
+              sm="6"
+              cols="12"
+              :class="isDark ? 'darkModeCardFeatureEvent' : 'lightModeCardFeatureEvent'"
+              class="pa-4 px-5 mx-3"
+            >
               <p class="google-font my-2">Not Found</p>
             </v-col>
           </v-row>
@@ -39,13 +43,19 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import service from "@/services/appservices";
 export default {
   name: "App",
-  inject: ["theme"],
   components: {
     // featureEventCard: () => import("@/components/home/FeatureEventCard")
     EventCardVue: () => import("@/components/events/EventCard"),
+  },
+  setup() {
+    const theme = useTheme()
+    const isDark = computed(() => theme.global.current.value.dark)
+    return { isDark }
   },
   data: () => ({
     loading: true,

--- a/src/components/home/FeaturesModules.vue
+++ b/src/components/home/FeaturesModules.vue
@@ -13,16 +13,20 @@
         <v-container fluid class="py-0 my-0">
           <v-row class="py-0 my-0" v-if="loading && notFound == false">
             <v-col v-for="i in 4" :key="i" md="3" lg="3" sm="6" cols="6" class="pa-2">
-              <v-sheet :color="`grey ${theme.isDark ? 'darken-2' : 'lighten-4'}`" class>
+              <v-sheet :color="`grey ${isDark ? 'darken-2' : 'lighten-4'}`" class>
                 <v-skeleton-loader class="mx-auto" type="article"></v-skeleton-loader>
               </v-sheet>
             </v-col>
           </v-row>
           <v-row class="py-0 my-0" v-else-if="notFound">
-            <v-col md="3" lg="3" sm="6" cols="12" :class="$vuetify.theme.dark
-                ? 'darkModeCardFeatureEvent'
-                : 'lightModeCardFeatureEvent'
-              " class="pa-4 px-5 mx-3">
+            <v-col
+              md="3"
+              lg="3"
+              sm="6"
+              cols="12"
+              :class="isDark ? 'darkModeCardFeatureEvent' : 'lightModeCardFeatureEvent'"
+              class="pa-4 px-5 mx-3"
+            >
               <p class="google-font my-2">Not Found</p>
             </v-col>
           </v-row>
@@ -39,13 +43,19 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import service from "@/services/appservices";
 export default {
   name: "App",
-  inject: ["theme"],
   components: {
     // featureEventCard: () => import("@/components/home/FeatureEventCard")
     ModuleCardVue: () => import("@/components/modules/ModuleCard"),
+  },
+  setup() {
+    const theme = useTheme()
+    const isDark = computed(() => theme.global.current.value.dark)
+    return { isDark }
   },
   data: () => ({
     loading: true,

--- a/src/components/speakers/SpeakerDesktop.vue
+++ b/src/components/speakers/SpeakerDesktop.vue
@@ -32,7 +32,7 @@
             <v-col cols="12" sm="12">
               <v-card
                 elevation="0"
-                :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+                :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
               >
                 <v-card-text class="px-5 pb-5">
                   <v-container fluid class="my-0 pa-0">
@@ -64,11 +64,7 @@
                         <p
                           class="my-0 mt-3 google-font"
                           style="font-size: 150%"
-                          :style="{
-                            color: this.$vuetify.theme.dark
-                              ? 'white'
-                              : '#424242',
-                          }"
+                          :style="{ color: isDark ? 'white' : '#424242' }"
                         >
                           {{ speaker.name }}
                         </p>
@@ -78,11 +74,7 @@
                         <p
                           class="my-0 google-font"
                           style="font-size: 110%"
-                          :style="{
-                            color: this.$vuetify.theme.dark
-                              ? 'white'
-                              : '#424242',
-                          }"
+                          :style="{ color: isDark ? 'white' : '#424242' }"
                         >
                           {{ speaker.company.name }}
                         </p>
@@ -110,7 +102,7 @@
               <v-card
                 flat
                 class="pa-4"
-                :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+                :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
               >
                 <v-card-title class="google-font">Sessions:</v-card-title>
                 <v-card-text>
@@ -122,7 +114,7 @@
                       v-for="sess in events"
                       :key="sess.id"
                     >
-                    <div style="cursor: pointer;" @click="$router.push({ path: '/events/' + sess.id })" class="pa-4" :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-white'">
+                    <div style="cursor: pointer;" @click="$router.push({ path: '/events/' + sess.id })" class="pa-4" :class="isDark ? 'aura-card-dark' : 'aura-card-white'">
                       <p class="mb-0">{{ convtDate(sess.date)}}</p>
                       <p style="font-size: 130%;" class="mb-0"><b>{{ sess.name }}</b></p>
                     </div>
@@ -146,7 +138,7 @@
           sm="11"
           xs="12"
           class="pt-3"
-          :class="$vuetify.theme.dark == true ? 'aura-card-dark' : 'aura-card-light'"
+          :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
         >
           <v-container fluid>
             <v-row>

--- a/src/components/speakers/SpeakerMobile.vue
+++ b/src/components/speakers/SpeakerMobile.vue
@@ -21,7 +21,7 @@
                 <v-img
                   :src="getImgUrl(speaker.image, 'profile.jpg')"
                   style="border-style: solid;border-width: 5px;"
-                  :style="{'border-color':this.$vuetify.theme.dark?'#424242':'white'}"
+                  :style="{'border-color': isDark ? '#424242':'white'}"
                 >
                   <template v-slot:placeholder>
                     <v-row class="fill-height ma-0" align="center" justify="center">
@@ -33,13 +33,13 @@
               <p
                 class="my-0 mt-3 google-font"
                 style="font-size:150%;"
-                :style="{color:this.$vuetify.theme.dark?'white':'#424242'}"
+                :style="{color: isDark ? 'white':'#424242'}"
               >{{speaker.name}}</p>
               <p class="google-font my-0" style="font-size:110%">{{ speaker.designation }}</p>
               <p
                 class="my-0 google-font"
                 style="font-size:110%"
-                :style="{color:this.$vuetify.theme.dark?'white':'#424242'}"
+                :style="{color: isDark ? 'white':'#424242'}"
               >{{speaker.company.name}}</p>
               <p class="google-font my-0">{{ speaker.city }}, {{ speaker.country }}</p>
             </v-col>
@@ -90,7 +90,7 @@
         sm="11"
         xs="12"
         class="pt-3"
-        :class="$vuetify.theme.dark == true?'aura-card-dark':'aura-card-white'"
+        :class="isDark ? 'aura-card-dark':'aura-card-white'"
       >
         <v-container fluid>
           <v-row>

--- a/src/components/team/CoreTeamMemberCard.vue
+++ b/src/components/team/CoreTeamMemberCard.vue
@@ -5,9 +5,7 @@
         v-on="on"
         style="cursor: pointer"
         class="py-5 ma-1 fill-height"
-        :class="
-          $vuetify.theme.dark == true ? 'aura-card-dark' : 'aura-card-light'
-        "
+        :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
       >
         <div class="text-center">
           <v-avatar size="100">
@@ -42,7 +40,7 @@
 
     <v-card
       class="pa-md-8 pa-sm-8 pa-4 google-font"
-      :class="theme.isDark ? 'grey darken-3' : 'white'"
+      :class="isDark ? 'grey darken-3' : 'white'"
       style="border-radius: 12px"
     >
       <v-avatar size="150" style="border-radius: 15px;">
@@ -60,7 +58,7 @@
         <p class="mb-1"><b>Bio:</b></p>
         <p class="google-font" style="font-size: 90%;">{{ data.bio }}</p>
       </div>
-      <v-toolbar dense flat :color="this.$vuetify.theme.dark ? '#252726' : '#F5F8FC'" style="border-radius: 30px;">
+      <v-toolbar dense flat :color="isDark ? '#252726' : '#F5F8FC'" style="border-radius: 30px;">
         <socialMediaDetails class="pl-0 ml-0" :data="data.socialLinks" />
         <v-spacer></v-spacer>
         <v-btn class="aura-btn" dark rounded small depressed @click="goToTeam(data.id)"
@@ -72,13 +70,19 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import socialMediaDetails from "@/components/common/SocialInfo";
 export default {
   components: {
     socialMediaDetails,
   },
-  inject: ["theme"],
   props: ["data"],
+  setup() {
+    const theme = useTheme()
+    const isDark = computed(() => theme.global.current.value.dark)
+    return { isDark }
+  },
   data() {
     return {
       dialog: false,

--- a/src/functions/generalFunctions.js
+++ b/src/functions/generalFunctions.js
@@ -1,4 +1,12 @@
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
+
 export default {
+    setup() {
+        const theme = useTheme()
+        const isDark = computed(() => theme.global.current.value.dark)
+        return { isDark }
+    },
     methods: {
         checkExistance: (link, size) => (link && link.length > size),
         getCharString: (data) => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,17 +1,15 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 import App from './App.vue'
 import './registerServiceWorker'
 import router from './router'
 import store from './store'
-import vuetify from './plugins/vuetify';
+import vuetify from './plugins/vuetify'
 import generalFunctions from './functions/generalFunctions'
 import './style.css'
 
-Vue.config.productionTip = false
-Vue.mixin(generalFunctions); 
-new Vue({
-  router,
-  store,
-  vuetify,
-  render: h => h(App)
-}).$mount('#app')
+const app = createApp(App)
+app.use(router)
+app.use(store)
+app.use(vuetify)
+app.mixin(generalFunctions)
+app.mount('#app')

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,26 +1,29 @@
-import Vue from 'vue';
-import Vuetify from 'vuetify';
-import 'vuetify/dist/vuetify.min.css';
-import colors from 'vuetify/lib/util/colors'
+import 'vuetify/styles'
+import { createVuetify } from 'vuetify'
+import { aliases, mdi } from 'vuetify/iconsets/mdi'
 import 'material-design-icons-iconfont/dist/material-design-icons.css'
 
-Vue.use(Vuetify);
-
-export default new Vuetify({
+export default createVuetify({
   icons: {
-    iconfont: 'mdi', // default - only for display purposes
+    defaultSet: 'mdi',
+    aliases,
+    sets: { mdi },
   },
   theme: {
     themes: {
       light: {
-        primary: colors.blue,
-        secondary: colors.grey.darken1,
-        accent: colors.shades.black,
-        error: colors.red.accent3,
+        colors: {
+          primary: '#2196F3',
+          secondary: '#757575',
+          accent: '#000000',
+          error: '#ff1744',
+        },
       },
       dark: {
-        primary: colors.blue,
+        colors: {
+          primary: '#2196F3',
+        },
       },
     },
   },
-});
+})

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,4 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-
-Vue.use(VueRouter)
+import { createRouter, createWebHistory } from 'vue-router'
 
 // ✅ Helper: Load component secara dinamis
 const loadView = (view) => () => import(`../views/${view}`)
@@ -158,7 +155,7 @@ const routes = [
   },
   ...basicRoutes,
   {
-    path: '*',
+    path: '/:pathMatch(.*)*',
     name: 'Redirect',
     redirect: '/',
     ...withMeta({ title: 'Redirect' })
@@ -166,11 +163,10 @@ const routes = [
 ]
 
 // ✅ Konfigurasi Vue Router
-const router = new VueRouter({
-  mode: 'history',
-  base: process.env.BASE_URL,
+const router = createRouter({
+  history: createWebHistory(process.env.BASE_URL),
   scrollBehavior() {
-    return { x: 0, y: 0 }
+    return { left: 0, top: 0 }
   },
   routes
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,11 +1,8 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
+import { createStore } from 'vuex'
 import firebase from '@/config/firebase'
 
 // Optional: Import modules
 // import auth from './modules/auth'
-
-Vue.use(Vuex)
 
 // Nav item data config
 const navItemsData = [
@@ -20,7 +17,7 @@ const navItemsData = [
   // { text: 'Blogs', to: '/blogs', icon: 'mdi-newspaper-variant-multiple-outline', showToolbar: true, showBottomNav: false },
 ]
 
-export default new Vuex.Store({
+export default createStore({
   state: {
     drawer: false,
     eventDrawer: true,

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -66,7 +66,7 @@
             <v-row>
               <v-col
                 class="pa-8 google-font"
-                :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+                :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
                 md="12"
                 sm="12"
                 cols="12"
@@ -87,6 +87,8 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import service from "@/services/appservices";
 import { mapState } from "vuex";
 
@@ -95,6 +97,11 @@ export default {
   components: {
     communityGuidelines: () => import("@/components/about/CommunityGuidelines"),
     antiHarassmentPolicy: () => import("@/components/about/AntiHar"),
+  },
+  setup() {
+    const theme = useTheme()
+    const isDark = computed(() => theme.global.current.value.dark)
+    return { isDark }
   },
   computed: {
     ...mapState(["config"]),

--- a/src/views/Events/About.vue
+++ b/src/views/Events/About.vue
@@ -54,7 +54,7 @@
           cols="12"
           md="12"
           class="pa-md-5 pa-3 mt-n3"
-          :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+          :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
         >
           <v-container fluid>
             <p class="py-3" style="">
@@ -92,11 +92,7 @@
             </p>
 
             <h1
-              :class="
-                this.$vuetify.theme.dark
-                  ? 'white--text'
-                  : 'grey--text text--darken-3'
-              "
+              :class="isDark ? 'white--text' : 'grey--text text--darken-3'"
               class="google-font mb-2"
               style="font-size: 180%"
             >
@@ -192,7 +188,7 @@
     <v-container
       fluid
       class="aura-event-card mt-4 mb-5 d-none d-sm-block d-md-block d-lg-block"
-      :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+      :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
     >
       <!-- Other Data -->
       <v-row class="pa-3">
@@ -201,7 +197,7 @@
           <v-container
             fluid
             class="pa-5"
-            :class="$vuetify.theme.dark ? 'aura-card-dark-secondary' : 'aura-card-white'"
+            :class="isDark ? 'aura-card-dark-secondary' : 'aura-card-white'"
           >
             <v-row>
               <v-col
@@ -253,7 +249,7 @@
           <v-container
             fluid
             class="pa-5"
-            :class="$vuetify.theme.dark ? 'aura-card-dark-secondary' : 'aura-card-white'"
+            :class="isDark ? 'aura-card-dark-secondary' : 'aura-card-white'"
           >
             <v-row
               class="pa-0"

--- a/src/views/Events/MainView.vue
+++ b/src/views/Events/MainView.vue
@@ -19,7 +19,7 @@
     <v-main
       v-else
       class="pa-0 ma-0"
-      :class="this.$vuetify.theme.dark ? 'black' : 'white'"
+      :class="isDark ? 'black' : 'white'"
     >
       <v-container fluid>
         <v-row align="center" justify="center">

--- a/src/views/Events/Schedule.vue
+++ b/src/views/Events/Schedule.vue
@@ -14,7 +14,7 @@
                   :items="eventDetails.agenda"
                   :items-per-page="5"
                   class="ma-0 pa-0 mt-3"
-                  :class="$vuetify.theme.dark?'aura-card-dark' : 'aura-card-light'"
+                  :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
                   >
               </v-data-table>
             </v-col>

--- a/src/views/Events/Speaker.vue
+++ b/src/views/Events/Speaker.vue
@@ -19,11 +19,7 @@
       >
         <v-col cols="12" md="12">
           <h2
-            :class="
-              this.$vuetify.theme.dark
-                ? 'white--text'
-                : 'grey--text text--darken-3'
-            "
+            :class="isDark ? 'white--text' : 'grey--text text--darken-3'"
             class="google-font mb-0"
           >
             No Speaker Found.

--- a/src/views/Events/Team.vue
+++ b/src/views/Events/Team.vue
@@ -8,7 +8,7 @@
       </v-row>
       <v-row justify="center" align="center" class="py-5" v-else-if="sData.length<=0 && !isLoading">
         <v-col cols="12" md="12">
-          <h2 :class="this.$vuetify.theme.dark?'white--text':'grey--text text--darken-3'" class="google-font mb-0">No Speaker Found.</h2>
+          <h2 :class="isDark ? 'white--text':'grey--text text--darken-3'" class="google-font mb-0">No Speaker Found.</h2>
           <!-- <p class="google-font" style="font-size:120%">No Speaker Found.</p> -->
         </v-col>
       </v-row>

--- a/src/views/Modules/About.vue
+++ b/src/views/Modules/About.vue
@@ -54,7 +54,7 @@
           cols="12"
           md="12"
           class="pa-md-5 pa-3 mt-n3"
-          :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+          :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
         >
           <v-container fluid>
             <p class="py-3" style="">
@@ -92,11 +92,7 @@
             </p>
 
             <h1
-              :class="
-                this.$vuetify.theme.dark
-                  ? 'white--text'
-                  : 'grey--text text--darken-3'
-              "
+              :class="isDark ? 'white--text' : 'grey--text text--darken-3'"
               class="google-font mb-2"
               style="font-size: 180%"
             >
@@ -192,7 +188,7 @@
     <v-container
       fluid
       class="aura-event-card mt-4 mb-5 d-none d-sm-block d-md-block d-lg-block"
-      :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+      :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
     >
       <!-- Other Data -->
       <v-row class="pa-3">
@@ -201,7 +197,7 @@
           <v-container
             fluid
             class="pa-5"
-            :class="$vuetify.theme.dark ? 'aura-card-dark-secondary' : 'aura-card-white'"
+            :class="isDark ? 'aura-card-dark-secondary' : 'aura-card-white'"
           >
             <v-row>
               <v-col
@@ -253,7 +249,7 @@
           <v-container
             fluid
             class="pa-5"
-            :class="$vuetify.theme.dark ? 'aura-card-dark-secondary' : 'aura-card-white'"
+            :class="isDark ? 'aura-card-dark-secondary' : 'aura-card-white'"
           >
             <v-row
               class="pa-0"

--- a/src/views/Modules/MainView.vue
+++ b/src/views/Modules/MainView.vue
@@ -19,7 +19,7 @@
     <v-main
       v-else
       class="pa-0 ma-0"
-      :class="this.$vuetify.theme.dark ? 'black' : 'white'"
+      :class="isDark ? 'black' : 'white'"
     >
       <v-container fluid>
         <v-row align="center" justify="center">

--- a/src/views/Modules/Schedule.vue
+++ b/src/views/Modules/Schedule.vue
@@ -14,7 +14,7 @@
                   :items="eventDetails.agenda"
                   :items-per-page="5"
                   class="ma-0 pa-0 mt-3"
-                  :class="$vuetify.theme.dark?'aura-card-dark' : 'aura-card-light'"
+                  :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
                   >
               </v-data-table>
             </v-col>

--- a/src/views/Modules/Speaker.vue
+++ b/src/views/Modules/Speaker.vue
@@ -19,11 +19,7 @@
       >
         <v-col cols="12" md="12">
           <h2
-            :class="
-              this.$vuetify.theme.dark
-                ? 'white--text'
-                : 'grey--text text--darken-3'
-            "
+            :class="isDark ? 'white--text' : 'grey--text text--darken-3'"
             class="google-font mb-0"
           >
             No Speaker Found.

--- a/src/views/Modules/Team.vue
+++ b/src/views/Modules/Team.vue
@@ -8,7 +8,7 @@
       </v-row>
       <v-row justify="center" align="center" class="py-5" v-else-if="sData.length<=0 && !isLoading">
         <v-col cols="12" md="12">
-          <h2 :class="this.$vuetify.theme.dark?'white--text':'grey--text text--darken-3'" class="google-font mb-0">No Speaker Found.</h2>
+          <h2 :class="isDark ? 'white--text':'grey--text text--darken-3'" class="google-font mb-0">No Speaker Found.</h2>
           <!-- <p class="google-font" style="font-size:120%">No Speaker Found.</p> -->
         </v-col>
       </v-row>

--- a/src/views/Speakers/SpeakerDetails.vue
+++ b/src/views/Speakers/SpeakerDetails.vue
@@ -14,7 +14,6 @@
 <script>
 export default {
   name: "SpeakerPage",
-  inject: ["theme"],
   components: {
       SpeakerDesktop:()=>import('@/components/speakers/SpeakerDesktop'),
       SpeakerMobile:()=>import('@/components/speakers/SpeakerMobile')

--- a/src/views/SpeakersPage.vue
+++ b/src/views/SpeakersPage.vue
@@ -46,7 +46,7 @@
                 <div
                   class="py-5"
                   :class="
-                    $vuetify.theme.dark == true ? 'aura-card-dark' : 'aura-card-light'
+                    isDark ? 'aura-card-dark' : 'aura-card-light'
                   "
                 >
                   <SpeakerView :data="item" />
@@ -65,7 +65,7 @@
             <v-row v-if="loader">
               <v-col md="2" lg="2" sm="3" cols="6" v-for="i in 6" :key="i">
                 <v-sheet
-                  :color="`grey ${theme.isDark ? 'darken-2' : 'lighten-4'}`"
+                  :color="`grey ${isDark ? 'darken-2' : 'lighten-4'}`"
                   class
                 >
                   <v-skeleton-loader
@@ -86,12 +86,18 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import service from "@/services/appservices";
 export default {
   name: "SpeakerPage",
-  inject: ["theme"],
   components: {
     SpeakerView: () => import("@/components/speakers/Speakerview"),
+  },
+  setup() {
+    const theme = useTheme()
+    const isDark = computed(() => theme.global.current.value.dark)
+    return { isDark }
   },
   data: () => ({
     loader: true,

--- a/src/views/Team/TeamDetails.vue
+++ b/src/views/Team/TeamDetails.vue
@@ -41,7 +41,7 @@
               <v-col md="3" lg="3" sm="4" cols="12">
                 <div
                   class="pa-4"
-                  :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+                  :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
                 >
                   <v-avatar size="150" style="border-radius: 12px">
                     <img
@@ -76,7 +76,7 @@
               <v-col md="9" lg="9" sm="8" cols="12">
                 <div
                   class="pa-md-8 pa-4"
-                  :class="$vuetify.theme.dark ? 'aura-card-dark' : 'aura-card-light'"
+                  :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
                 >
                   <p class="mb-0">
                     <b>Bio</b>
@@ -123,7 +123,7 @@
           sm="11"
           xs="12"
           class="pt-3"
-          :class="$vuetify.theme.dark == true ? 'aura-card-dark' : 'aura-card-light'"
+          :class="isDark ? 'aura-card-dark' : 'aura-card-light'"
         >
           <v-container fluid>
             <v-row>

--- a/src/views/TeamPage.vue
+++ b/src/views/TeamPage.vue
@@ -57,7 +57,7 @@
             <v-row v-if="loader">
               <v-col md="2" lg="2" sm="3" cols="6" v-for="i in 6" :key="i">
                 <v-sheet
-                  :color="`grey ${theme.isDark ? 'darken-2' : 'lighten-4'}`"
+                  :color="`grey ${isDark ? 'darken-2' : 'lighten-4'}`"
                   class=""
                 >
                   <v-skeleton-loader
@@ -107,7 +107,7 @@
             <v-row v-if="loader">
               <v-col md="2" lg="2" sm="3" cols="6" v-for="i in 6" :key="i">
                 <v-sheet
-                  :color="`grey ${theme.isDark ? 'darken-2' : 'lighten-4'}`"
+                  :color="`grey ${isDark ? 'darken-2' : 'lighten-4'}`"
                   class=""
                 >
                   <v-skeleton-loader
@@ -136,17 +136,23 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import service from "@/services/appservices";
 import { mapState } from "vuex";
 export default {
   name: "TeamPage",
-  inject: ["theme"],
   computed: {
     ...mapState(["config"]),
   },
   components: {
     organizingTeamList: () => import("@/components/team/OrganizingTeamList"),
     CoreTeamMemberCard: () => import("@/components/team/CoreTeamMemberCard"),
+  },
+  setup() {
+    const theme = useTheme()
+    const isDark = computed(() => theme.global.current.value.dark)
+    return { isDark }
   },
   data: () => ({
     loader: true,

--- a/src/views/Volunteer.vue
+++ b/src/views/Volunteer.vue
@@ -1,6 +1,6 @@
 <template>
     <v-main class="px-0 mx-0">
-        <v-container fluid class="pa-0 mx-0" :class="this.$vuetify.theme.dark == true?'grey darken-4':'grey lighten-4'" >
+        <v-container fluid class="pa-0 mx-0" :class="isDark ? 'grey darken-4':'grey lighten-4'" >
              <v-row justify="center" align="center" class="py-0">
                 <v-col md="12" lg="10" sm="11" xs="12" class="pt-5"  >
                   <v-container fluid class="py-0 my-0 mt-2">
@@ -27,7 +27,7 @@
 
         <v-container fluid class="pa-0">
            
-            <v-row justify="center" align="center" class="py-3" :class="this.$vuetify.theme.dark == true?'black':''">
+            <v-row justify="center" align="center" class="py-3" :class="isDark ? 'black':''">
                 <v-col md="12" lg="10" sm="11" xs="12" class="pt-3 " v-if="Volunteers.length>0"  >
                     <v-data-iterator
                         :items="Volunteers"
@@ -68,7 +68,7 @@
                       <v-row >
                           <v-col md="2" lg="2" sm="3" cols="6" v-for="i in 6" :key="i">
                                 <v-sheet
-                                    :color="`grey ${theme.isDark ? 'darken-2' : 'lighten-4'}`"
+                                    :color="`grey ${isDark ? 'darken-2' : 'lighten-4'}`"
                                     class=""
                                 >
                                     <v-skeleton-loader
@@ -89,12 +89,18 @@
 </template>
 
 <script>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
 import service from '@/services/appservices'
 export default {
     name:'TeamVolunteerPage',
-    inject: ['theme'],
     components:{
         Volunteers:()=>import('@/components/team/Volunteers'),
+    },
+    setup(){
+        const theme = useTheme()
+        const isDark = computed(() => theme.global.current.value.dark)
+        return { isDark }
     },
     data:() =>({
       loader:true,


### PR DESCRIPTION
## Summary
- upgrade Vue stack to version 3 and update related dependencies
- migrate entrypoint, router, store and Vuetify plugin to Vue 3 APIs
- fix lint issue in AboutHeader component
- refactor dark-theme access to use Vuetify 3 composables and remove Vue 2 style injections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896fdfbd2ac832988adb9255615a4e1