### PR TITLE
refactor: await feature data

### DIFF
--- a/src/components/home/FeaturesEvents.vue
+++ b/src/components/home/FeaturesEvents.vue
@@ -65,45 +65,46 @@ export default {
     eData: [],
     featureEvendsData: [],
   }),
-  mounted() {
-    this.getFeaturesEventID();
+  async mounted() {
+    await this.getFeaturesEventID();
   },
   methods: {
-    getAllCustomEvents() {
+    async getAllCustomEvents() {
       this.featureEvendsData = [];
-      service.getAllCustomEvents().then((res) => {
-        if (res.success) {
-          this.loading = false;
-          this.AllCustomEvents = res.data;
+      const res = await service.getAllCustomEvents();
+      if (res.success) {
+        this.loading = false;
+        this.AllCustomEvents = res.data;
 
-          this.FeaturesEventID.map((res) => {
-            this.AllCustomEvents.map((obj) => {
-              if (obj.id == res) {
-                this.featureEvendsData.push(obj);
-              }
-            });
+        this.FeaturesEventID.map((res) => {
+          this.AllCustomEvents.map((obj) => {
+            if (obj.id == res) {
+              this.featureEvendsData.push(obj);
+            }
           });
-          this.featureEvendsData = this.featureEvendsData.sort((a, b) => new Date(b.date) - new Date(a.date))
-        }
-      });
+        });
+        this.featureEvendsData = this.featureEvendsData.sort(
+          (a, b) => new Date(b.date) - new Date(a.date)
+        );
+      }
     },
 
-    getFeaturesEventID() {
+    async getFeaturesEventID() {
       this.loading = true;
-      service.getFeaturesEvents().then((res) => {
-        if (res.success) {
-          this.notFound = false;
-          this.FeaturesEventID = res.data;
-          if (this.FeaturesEventID.length > 0) this.getAllCustomEvents();
-          else {
-            this.notFound = true;
-            this.loading = false;
-          }
+      const res = await service.getFeaturesEvents();
+      if (res.success) {
+        this.notFound = false;
+        this.FeaturesEventID = res.data;
+        if (this.FeaturesEventID.length > 0) {
+          await this.getAllCustomEvents();
         } else {
           this.notFound = true;
           this.loading = false;
         }
-      });
+      } else {
+        this.notFound = true;
+        this.loading = false;
+      }
     },
   },
 };

--- a/src/components/home/FeaturesModules.vue
+++ b/src/components/home/FeaturesModules.vue
@@ -65,45 +65,46 @@ export default {
     eData: [],
     featureEvendsData: [],
   }),
-  mounted() {
-    this.getFeaturesEventID();
+  async mounted() {
+    await this.getFeaturesEventID();
   },
   methods: {
-    getAllCustomEvents() {
+    async getAllCustomEvents() {
       this.featureEvendsData = [];
-      service.getAllCustomEvents().then((res) => {
-        if (res.success) {
-          this.loading = false;
-          this.AllCustomEvents = res.data;
+      const res = await service.getAllCustomEvents();
+      if (res.success) {
+        this.loading = false;
+        this.AllCustomEvents = res.data;
 
-          this.FeaturesEventID.map((res) => {
-            this.AllCustomEvents.map((obj) => {
-              if (obj.id == res) {
-                this.featureEvendsData.push(obj);
-              }
-            });
+        this.FeaturesEventID.map((res) => {
+          this.AllCustomEvents.map((obj) => {
+            if (obj.id == res) {
+              this.featureEvendsData.push(obj);
+            }
           });
-          this.featureEvendsData = this.featureEvendsData.sort((a, b) => new Date(b.date) - new Date(a.date))
-        }
-      });
+        });
+        this.featureEvendsData = this.featureEvendsData.sort(
+          (a, b) => new Date(b.date) - new Date(a.date)
+        );
+      }
     },
 
-    getFeaturesEventID() {
+    async getFeaturesEventID() {
       this.loading = true;
-      service.getFeaturesEvents().then((res) => {
-        if (res.success) {
-          this.notFound = false;
-          this.FeaturesEventID = res.data;
-          if (this.FeaturesEventID.length > 0) this.getAllCustomEvents();
-          else {
-            this.notFound = true;
-            this.loading = false;
-          }
+      const res = await service.getFeaturesEvents();
+      if (res.success) {
+        this.notFound = false;
+        this.FeaturesEventID = res.data;
+        if (this.FeaturesEventID.length > 0) {
+          await this.getAllCustomEvents();
         } else {
           this.notFound = true;
           this.loading = false;
         }
-      });
+      } else {
+        this.notFound = true;
+        this.loading = false;
+      }
     },
   },
 };

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -6,7 +6,7 @@
           <HomeStartScreen class="mt-0 mb-15" />
           <WhatWeDo />
           <AboutCommunity class="mt-5" />
-          <featureModules v-if="showFeatureModuleStatus" class="my-15" />
+          <featureModules v-if="featureEvents.length > 0" class="my-15" />
           <partners class="my-15" />
         </v-col>
       </v-row>
@@ -28,23 +28,22 @@ export default {
     partners: () => import("@/components/common/Partners"),
   },
   data: () => ({
-    showFeatureModuleStatus: false,
+    featureEvents: [],
   }),
-  mounted() {
-    this.getFeaturesEvent();
+  async mounted() {
+    await this.getFeaturesEvent();
   },
   computed: {
     ...mapState(["config"]),
   },
   methods: {
-    getFeaturesEvent() {
-      service.getFeaturesEvents().then((res) => {
-        res.success
-          ? res.data.length > 0
-            ? (this.showFeatureModuleStatus = true)
-            : (this.showFeatureModuleStatus = false)
-          : (this.notFound = true);
-      });
+    async getFeaturesEvent() {
+      try {
+        const res = await service.getFeaturesEvents();
+        this.featureEvents = res.success ? res.data : [];
+      } catch (e) {
+        this.featureEvents = [];
+      }
     },
   },
 };


### PR DESCRIPTION
## Summary
- use async/await for feature events fetching on home page
- await feature and custom event calls in FeaturesModules and FeaturesEvents
- rely on reactive arrays instead of promises in templates

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897d41d55948329b9bd6a86bddbfc92