### PR TITLE
Use Beacon transport for Google Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
-    gtag('config', 'G-D2QP4YRN1N');
+    gtag('config', 'G-D2QP4YRN1N', { transport_type: 'beacon' });
   </script>
 </head>
 


### PR DESCRIPTION
## Summary
- Configure Google Analytics to use `transport_type: 'beacon'` so events are not sent during deprecated `unload` lifecycle.

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897e308684c83298c3297e2a2ec6bc9