### PR TITLE
fix: register Vuetify components and directives

### DIFF
--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,9 +1,13 @@
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
 import { aliases, mdi } from 'vuetify/iconsets/mdi'
 import 'material-design-icons-iconfont/dist/material-design-icons.css'
 
 export default createVuetify({
+  components,
+  directives,
   icons: {
     defaultSet: 'mdi',
     aliases,


### PR DESCRIPTION
## Summary
- register Vuetify components and directives to avoid unresolved component warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: vue-cli-service: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab895df78832982c9b1dd5b8c3bac