### PR TITLE
fix: resolve router and theme warnings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,8 +67,9 @@ export default {
   },
   setup() {
     const theme = useTheme();
-    theme.global.name.value =
-      localStorage.getItem("darkMode") === "true" ? "dark" : "light";
+    theme.change(
+      localStorage.getItem("darkMode") === "true" ? "dark" : "light"
+    );
   },
   data: () => ({
     isLoading: true,

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,9 +1,13 @@
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
 import { aliases, mdi } from 'vuetify/iconsets/mdi'
 import 'material-design-icons-iconfont/dist/material-design-icons.css'
 
 export default createVuetify({
+  components,
+  directives,
   icons: {
     defaultSet: 'mdi',
     aliases,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -60,7 +60,7 @@ const routes = [
     component: loadView('Modules/MainView.vue'),
     children: [
       {
-        path: '/',
+        path: '',
         name: 'CustomModuleHome',
         component: loadView('Modules/About.vue'),
         meta: { isModule: true }
@@ -88,13 +88,8 @@ const routes = [
         name: 'CustomModuleResources',
         component: loadView('Modules/Resources.vue'),
         meta: { isModule: true }
-      },
-      {
-        path: '',
-        name: 'redirectCustomModule',
-        redirect: '/',
-        meta: { isModule: true }
       }
+      // Default child route already handles '/modules/:id'
     ]
   },
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,10 +1,9 @@
 const { defineConfig } = require('@vue/cli-service')
+const webpack = require('webpack')
 
 module.exports = defineConfig({
-  transpileDependencies: [
-    'vuetify'
-  ],
-  chainWebpack: config => {
+  transpileDependencies: ['vuetify'],
+  chainWebpack: (config) => {
     config.plugins.delete('prefetch')
   },
   productionSourceMap: false,
@@ -12,6 +11,11 @@ module.exports = defineConfig({
     performance: {
       hints: false,
     },
+    plugins: [
+      new webpack.DefinePlugin({
+        __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: JSON.stringify(false),
+      }),
+    ],
   },
   pwa: {
     name: 'Tamasuma Main',
@@ -28,5 +32,5 @@ module.exports = defineConfig({
       // swDest: 'service-worker.js',
       maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
     },
-  }
+  },
 })


### PR DESCRIPTION
## Summary
- register Vuetify components and directives to avoid unresolved component warnings
- make module child route relative and drop redundant redirect to fix router param warning
- switch to `theme.change` and define Vue hydration flag to remove upgrade notices

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: vue-cli-service: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab895df78832982c9b1dd5b8c3bac